### PR TITLE
Fix cross-component state reuse

### DIFF
--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -45,13 +45,16 @@ export function renderComponent(component: () => VNode, parent?: HTMLElement): H
             try {
                 // Render virtual DOM tree
                 const vnode = component();
-                
+
                 // Only render if the vnode actually changed
                 const cacheEntry = componentCache.get(container)!;
                 if (!cacheEntry.lastVNode || !areVNodesShallowEqual(cacheEntry.lastVNode, vnode)) {
                     render(vnode, container);
                     cacheEntry.lastVNode = vnode;
                 }
+
+                // Trim unused state slots when component structure changes
+                store.states.length = store.stateIndex;
             } catch (error) {
                 console.error('Error during component update:', error);
             } finally {


### PR DESCRIPTION
## Summary
- fix bug where leftover state data was reused when switching components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c235a3804832f80bde7072792b1c4